### PR TITLE
feat(actions): disable caching for GitHub REST API

### DIFF
--- a/src/app/http-github-no-cache-interceptor.ts
+++ b/src/app/http-github-no-cache-interceptor.ts
@@ -1,0 +1,28 @@
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Injectable } from '@angular/core';
+
+/**
+ * Interceptor that disables cache for GitHub REST API calls.
+ */
+@Injectable()
+export class HttpGithubNoCacheInterceptor implements HttpInterceptor {
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<any>> {
+    if (
+      req.url.includes('https://api.github.com/') &&
+      !req.url.includes('/graphql')
+    ) {
+      const headers = req.headers.set('If-None-Match', '');
+      req = req.clone({ headers });
+    }
+    return next.handle(req);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { DATE_PIPE_DEFAULT_OPTIONS } from '@angular/common';
 import { DEFAULT_DATE_TIME_FORMAT } from './app/constants';
+import { HttpGithubNoCacheInterceptor } from './app/http-github-no-cache-interceptor';
 
 if (environment.isEnableProdMode) {
   enableProdMode();
@@ -86,6 +87,11 @@ bootstrapApplication(AppComponent, {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: HttpGithubAuthorizationInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HttpGithubNoCacheInterceptor,
       multi: true,
     },
     provideAppInitializer(() => {


### PR DESCRIPTION
I looked into why data is not reloaded when opening the actions view.
It turns out that GitHub's REST API sends a cache header in its responses with a max-age of 60 seconds.
So data is simply cached for that time. If you reopen the Actions view within 60 seconds, data is not read from the server.
The next polling should reload data again.

To disable caching, I added an http interceptor to add the `If-None-Match` with an empty value.
I did so only for requests to GitHub's REST API.

Another option would be to just ignore it if we think that updating data every 60 seconds is enough.

@felix11h