### PR TITLE
fix(commits): environment tags in commits view and deploy dialog match

### DIFF
--- a/src/app/status-tag/status-tag-utils.ts
+++ b/src/app/status-tag/status-tag-utils.ts
@@ -1,11 +1,11 @@
 import { StatusTagColor } from './status-tag-color';
 
 export function getDeploymentEnvironmentColors(environmentNames: string[]) {
-  const set = new Set(environmentNames);
+  const set = new Set(environmentNames.toSorted());
   const colors = [
     StatusTagColor.GREEN,
-    StatusTagColor.YELLOW,
     StatusTagColor.BLUE,
+    StatusTagColor.YELLOW,
     StatusTagColor.RED,
     StatusTagColor.GRAY,
   ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "strict": true,
     "target": "ES2022",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2022", "dom", "esnext.asynciterable"],
+    "lib": ["es2023", "dom", "esnext.asynciterable"],
     "useDefineForClassFields": false
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Colors of environment tags could be different between commits view and deploy commit dialog when order of deployment is different from order of environments shown in the deploy commit dialog.

This is fixed now, but still colors of same environments in different repositories can be different, e.g. when repository A has environments dev, test and live and repository B only has dev and live.
This may be addressed in another PR.

### Before

<img width="1089" alt="before" src="https://github.com/user-attachments/assets/085fe73f-3225-457e-8780-fa5fb7008e6a" />


### After

<img width="1060" alt="after" src="https://github.com/user-attachments/assets/6e5376d6-2928-472a-a4f0-6cb875afa070" />
