### PR TITLE
fix(add-repositories): checkboxes are still checked after filtering

### DIFF
--- a/src/app/add-repository/add-repository-modal/add-repository-modal.component.html
+++ b/src/app/add-repository/add-repository-modal/add-repository-modal.component.html
@@ -39,6 +39,7 @@
           <mat-checkbox
             [id]="repository.nameWithOwner"
             [name]="repository.nameWithOwner"
+            [checked]="selectedRepositories.includes(repository.nameWithOwner)"
             (change)="checkboxClick(repository.nameWithOwner, $event)"
           >
             <div class="repository-list-item__label">


### PR DESCRIPTION
In the modal to add repositories, checked checkboxes were unchecked after filtering repositories list and removing filter again. Now, information of checked checkbox is restored correctly.